### PR TITLE
Add default registers for ensime, go-mode, intero and robe

### DIFF
--- a/smart-jump-ensime.el
+++ b/smart-jump-ensime.el
@@ -1,0 +1,40 @@
+;;; smart-jump-ensime.el --- Register `ensime-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen, Terje Larsen
+
+;; Author: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `ensime-mode' for `smart-jump'.
+
+;;; Code:
+(require 'smart-jump)
+(require 'ensime nil t)
+
+(defun smart-jump-ensime-register ()
+  "Register `ensime-mode' for `smart-jump'."
+  (smart-jump-register :modes 'ensime-mode
+                       :jump-fn 'ensime-edit-definition
+                       :pop-fn 'ensime-pop-find-definition-stack
+                       :refs-fn 'ensime-show-uses-of-symbol-at-point))
+
+(provide 'smart-jump-ensime)
+;;; smart-jump-ensime.el ends here

--- a/smart-jump-go-mode.el
+++ b/smart-jump-go-mode.el
@@ -35,7 +35,6 @@
   "Register `go-mode' for `smart-jump'."
   (smart-jump-register :modes 'go-mode
                        :jump-fn 'go-guru-definition
-                       :pop-fn 'xref-pop-marker-stack
                        :refs-fn 'go-guru-referrers))
 
 (provide 'smart-jump-go-mode)

--- a/smart-jump-go-mode.el
+++ b/smart-jump-go-mode.el
@@ -1,0 +1,42 @@
+;;; smart-jump-go-mode.el --- Register `go-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen, Terje Larsen
+
+;; Author: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `go-mode' for `smart-jump'.
+;;; This requires the `go-guru' package and the tool `guru' installed and
+;;; available on your $PATH.
+
+;;; Code:
+(require 'smart-jump)
+(require 'go-guru nil t)
+
+(defun smart-jump-go-mode-register ()
+  "Register `go-mode' for `smart-jump'."
+  (smart-jump-register :modes 'go-mode
+                       :jump-fn 'go-guru-definition
+                       :pop-fn 'xref-pop-marker-stack
+                       :refs-fn 'go-guru-referrers))
+
+(provide 'smart-jump-go-mode)
+;;; smart-jump-go-mode.el ends here

--- a/smart-jump-intero.el
+++ b/smart-jump-intero.el
@@ -1,0 +1,40 @@
+;;; smart-jump-intero.el --- Register `intero-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen, Terje Larsen
+
+;; Author: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `intero-mode' for `smart-jump'.
+
+;;; Code:
+(require 'smart-jump)
+(require 'intero nil t)
+
+(defun smart-jump-intero-register ()
+  "Register `intero-mode' for `smart-jump'."
+  (smart-jump-register :modes 'intero-mode
+                       :jump-fn 'intero-goto-definition
+                       :pop-fn 'xref-pop-marker-stack
+                       :refs-fn 'smart-jump-simple-find-references))
+
+(provide 'smart-jump-intero)
+;;; smart-jump-intero.el ends here

--- a/smart-jump-intero.el
+++ b/smart-jump-intero.el
@@ -33,7 +33,6 @@
   "Register `intero-mode' for `smart-jump'."
   (smart-jump-register :modes 'intero-mode
                        :jump-fn 'intero-goto-definition
-                       :pop-fn 'xref-pop-marker-stack
                        :refs-fn 'smart-jump-simple-find-references))
 
 (provide 'smart-jump-intero)

--- a/smart-jump-robe.el
+++ b/smart-jump-robe.el
@@ -33,7 +33,6 @@
   "Register `robe-mode' for `smart-jump'."
   (smart-jump-register :modes 'robe-mode
                        :jump-fn 'robe-jump
-                       :pop-fn 'xref-pop-marker-stack
                        :refs-fn 'smart-jump-simple-find-references))
 
 (provide 'smart-jump-robe)

--- a/smart-jump-robe.el
+++ b/smart-jump-robe.el
@@ -1,0 +1,40 @@
+;;; smart-jump-robe.el --- Register `robe-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen, Terje Larsen
+
+;; Author: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `robe-mode' for `smart-jump'.
+
+;;; Code:
+(require 'smart-jump)
+(require 'robe nil t)
+
+(defun smart-jump-robe-register ()
+  "Register `robe-mode' for `smart-jump'."
+  (smart-jump-register :modes 'robe-mode
+                       :jump-fn 'robe-jump
+                       :pop-fn 'xref-pop-marker-stack
+                       :refs-fn 'smart-jump-simple-find-references))
+
+(provide 'smart-jump-robe)
+;;; smart-jump-robe.el ends here

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -41,6 +41,7 @@ multiple fallbacks."
     cc-mode
     (clojure-mode cider cider-repl)
     elisp-slime-nav
+    ensime
     (js2-mode rjsx-mode)
     omnisharp
     slime

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -46,6 +46,7 @@ multiple fallbacks."
     intero
     (js2-mode rjsx-mode)
     omnisharp
+    robe
     slime
     tide)
   "The list of modes `smart-jump-setup-default-registers' uses to

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -43,6 +43,7 @@ multiple fallbacks."
     elisp-slime-nav
     ensime
     go-mode
+    intero
     (js2-mode rjsx-mode)
     omnisharp
     slime

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -42,6 +42,7 @@ multiple fallbacks."
     (clojure-mode cider cider-repl)
     elisp-slime-nav
     ensime
+    go-mode
     (js2-mode rjsx-mode)
     omnisharp
     slime


### PR DESCRIPTION
This adds the following default registers:

- [ensime](https://github.com/ensime/ensime-emacs)
- [go-mode guru](https://github.com/dominikh/go-mode.el)
- [intero](https://github.com/commercialhaskell/intero)
- [robe](https://github.com/dgutov/robe)

This is the configuration that has worked for me, however I am not so sure if I
need to specify the pop-fn or if it will fallback to `xref-pop-marker-stack`.

I am also not sure about the `:refs-fn`, for those that didn't have it I added
`smart-jump-simple-find-references` to prevent the xref fallback. Since the
simple one works better for those modes that don't utilize xref.

I was also not sure about the options:
- `:should-jump`
- `:heuristic`
- `:async`

So I haven't added them since it works without them.

I had smart-jump setup for several other modes but they are using xref by
various means so I guess there is nothing to provide there.