### PR TITLE
Add lsp-mode to smart-jump default registers

### DIFF
--- a/smart-jump-lsp-mode.el
+++ b/smart-jump-lsp-mode.el
@@ -1,0 +1,37 @@
+;;; smart-jump-lsp-mode.el --- Register `lsp-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen, Terje Larsen
+
+;; Author: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; Maintainer: James Nguyen <james@jojojames.com>, Terje Larsen <terlar@gmail.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `lsp-mode' for `smart-jump'.
+
+;;; Code:
+(require 'smart-jump)
+(require 'lsp-mode nil t)
+
+(defun smart-jump-lsp-mode-register ()
+  "Register `lsp-mode' for `smart-jump'."
+  (smart-jump-register :modes 'lsp-mode))
+
+(provide 'smart-jump-lsp-mode)
+;;; smart-jump-lsp-mode.el ends here

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -45,6 +45,7 @@ multiple fallbacks."
     go-mode
     intero
     (js2-mode rjsx-mode)
+    lsp-mode
     omnisharp
     robe
     slime


### PR DESCRIPTION
This adds support for `lsp-mode` which is using `xref` as backend.