### PR TITLE
Add xref modes

### DIFF
--- a/smart-jump-elm-mode.el
+++ b/smart-jump-elm-mode.el
@@ -1,0 +1,37 @@
+;;; smart-jump-elm-mode.el --- Register `elm-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen
+
+;; Author: James Nguyen <james@jojojames.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `elm-mode' for `smart-jump'.
+
+;;; Code:
+(require 'smart-jump)
+(require 'elm-mode nil t)
+
+(defun smart-jump-elm-mode-register ()
+  "Register `elm-mode' for `smart-jump'."
+  (smart-jump-register :modes 'elm-mode))
+
+(provide 'smart-jump-elm-mode)
+;;; smart-jump-elm-mode.el ends here

--- a/smart-jump-erlang-mode.el
+++ b/smart-jump-erlang-mode.el
@@ -1,0 +1,37 @@
+;;; smart-jump-erlang-mode.el --- Register `erlang-mode' for `smart-jump'. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2017 James Nguyen
+
+;; Author: James Nguyen <james@jojojames.com>
+;; Maintainer: James Nguyen <james@jojojames.com>
+;; URL: https://github.com/jojojames/smart-jump
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "25.1"))
+;; Keywords: emacs, tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;; Register `erlang-mode' for `smart-jump'.
+
+;;; Code:
+(require 'smart-jump)
+(require 'erlang-mode nil t)
+
+(defun smart-jump-erlang-mode-register ()
+  "Register `erlang-mode' for `smart-jump'."
+  (smart-jump-register :modes 'erlang-mode))
+
+(provide 'smart-jump-erlang-mode)
+;;; smart-jump-erlang-mode.el ends here

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -41,6 +41,7 @@ multiple fallbacks."
     cc-mode
     (clojure-mode cider cider-repl)
     elisp-slime-nav
+    elm-mode
     ensime
     go-mode
     intero

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -43,6 +43,7 @@ multiple fallbacks."
     elisp-slime-nav
     elm-mode
     ensime
+    erlang-mode
     go-mode
     intero
     (js2-mode rjsx-mode)


### PR DESCRIPTION
This adds elm-mode and erlang-mode as xref backend. However the official way
here is xref through generated tags, but I guess that is okay?

I were also considering adding the `emacs-lisp-mode` but see you already have
slime associated with that. What would happen in that case?