### PR TITLE
use rtags-rc-binary-name

### DIFF
--- a/smart-jump-cc-mode.el
+++ b/smart-jump-cc-mode.el
@@ -71,7 +71,7 @@
                                       (and
                                        (fboundp 'rtags-executable-find)
                                        (fboundp 'rtags-is-indexed)
-                                       (rtags-executable-find "rc")
+                                       (rtags-executable-find rtags-rc-binary-name)
                                        (rtags-is-indexed)))
                        :heuristic 'point
                        :async 2000


### PR DESCRIPTION
the value of this var defaults to "rc" and this way you can use an rc that is not in your path, via  `/path/to/rc`