### PR TITLE
added: smart-jump-find-references-with-rg

### DIFF
--- a/smart-jump.el
+++ b/smart-jump.el
@@ -571,6 +571,20 @@ to use xref as the fallback."
      "Install the emacs package ag to use\
  `smart-jump-simple-find-references-with-ag'.")))
 
+(defun smart-jump-find-references-with-rg ()
+  "Use `rg' to find references."
+  (interactive)
+  (if (fboundp 'rg-project)
+      (rg-project (cond ((use-region-p)
+                         (buffer-substring-no-properties (region-beginning)
+                                                         (region-end)))
+                        ((symbol-at-point)
+                         (substring-no-properties
+                          (symbol-name (symbol-at-point))))))
+    (message
+     "Install the emacs package rg to use\
+ `smart-jump-simple-find-references-with-rg'.")))
+
 (defun smart-jump-get-async-wait-time (async)
   "Return the time in seconds for use with waiting for an async jump.
 If ASYNC is a number, use to determine the wait time."

--- a/smart-jump.el
+++ b/smart-jump.el
@@ -580,7 +580,8 @@ to use xref as the fallback."
                                                          (region-end)))
                         ((symbol-at-point)
                          (substring-no-properties
-                          (symbol-name (symbol-at-point))))))
+                          (symbol-name (symbol-at-point)))))
+                  ".*")
     (message
      "Install the emacs package rg to use\
  `smart-jump-simple-find-references-with-rg'.")))


### PR DESCRIPTION
[BurntSushi/ripgrep: ripgrep recursively searches directories for a regex pattern](https://github.com/BurntSushi/ripgrep)
is some compatible to ag.
And faster than ag.